### PR TITLE
Fix typo in obsolete warning for PieSlice

### DIFF
--- a/Template10 (Library)/Controls/PiePiece.cs
+++ b/Template10 (Library)/Controls/PiePiece.cs
@@ -6,7 +6,7 @@ using Windows.UI.Xaml.Shapes;
 
 namespace Template10.Controls
 {
-    [Obsolete("Use RignSegment instead")]
+    [Obsolete("Use RingSegment instead")]
     public class PieSlice : Path
     {
         private bool _loaded = false;


### PR DESCRIPTION
Since I'm heavily using PieSlice, I noticed this :)
